### PR TITLE
Builds using 4 threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ cmake:
 	mkdir -p $(BUILDDIR)
 	git clone https://github.com/kitware/cmake $(BUILDDIR)/cmake
 	cd $(BUILDDIR)/cmake; git checkout c4ab098
-	cd $(BUILDDIR)/cmake; ./bootstrap --prefix=$(PREFIX)
-	cd $(BUILDDIR)/cmake; make
+	cd $(BUILDDIR)/cmake; ./bootstrap --prefix=$(PREFIX) --parallel=4
+	cd $(BUILDDIR)/cmake; make -j4
 	cd $(BUILDDIR)/cmake; make install

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ echo Using prefix: $PREFIX
 mkdir -p $BUILDDIR
 git clone https://github.com/kitware/cmake $BUILDDIR/cmake
 cd $BUILDDIR/cmake; git checkout 7700df9b1ef66761cad08cfc08344d5b27660e9f
-cd $BUILDDIR/cmake; ./bootstrap --prefix=$PREFIX
-cd $BUILDDIR/cmake; make
+cd $BUILDDIR/cmake; ./bootstrap --prefix=$PREFIX --parallel=4
+cd $BUILDDIR/cmake; make -j4
 cd $BUILDDIR/cmake; make install
 


### PR DESCRIPTION
## What this PR do?

Increases the amount of threads during build to 4 on Linux and Mac OS. As it seems that it uses a prebuilt version on Windows it wasn't tested